### PR TITLE
fix #7: keep allowed hosts in local storage

### DIFF
--- a/blok.js
+++ b/blok.js
@@ -1,125 +1,135 @@
-var blocklist_url = 'disconnect-blocklist.json';
 var blocklist = {};
+var allowedHosts = [];
 
-var current_active_tab_id;
+// HACK: Start with active tab id = 1 when browser starts
+var current_active_tab_id = 1;
 var current_active_origin;
 var blocked_requests = {};
 var total_exec_time = {};
-var disabled_tabs = [];
 
 
-function restartBlok(tabID) {
+function restartBlokForTab(tabID) {
   chrome.pageAction.hide(tabID);
   blocked_requests[tabID] = [];
   total_exec_time[tabID] = 0;
 }
 
 
-function getJSON(url) {
-  return new Promise(function(resolve, reject) {
+var getBlocklistJSON = new Promise(function(resolve, reject) {
     var xhr = new XMLHttpRequest();
-    xhr.open('get', url, true);
+    xhr.open('get', 'disconnect-blocklist.json', true);
     xhr.responseType = 'json';
     xhr.onload = function () {
       var status = xhr.status;
       if (status == 200) {
-        resolve(xhr.response);
+        var data = xhr.response;
+
+        // remove un-needed categories per disconnect
+        delete data.categories['Content'];
+        delete data.categories['Legacy Disconnect'];
+        delete data.categories['Legacy Content'];
+
+        // parse thru the disconnect blocklist and create
+        // local blocklist "grouped" by main domain. I.e.,
+        // blocklist["facebook.com"] = http://www.facebook.com
+        // blocklist["fb.com"] = http://www.facebook.com
+        // blocklist["doubleclick.net"] = http://www.google.com
+        // blocklist["google-analytics.com"] = http://www.google.com
+        // etc.
+        for (category_name in data.categories) {
+          var category = data.categories[category_name];
+          var entity_count = category.length;
+
+          for (var i = 0; i < entity_count; i++) {
+            var entity = category[i];
+
+            for (entity_name in entity) {
+              var urls = entity[entity_name];
+
+              for (main_domain in urls) {
+                blocklist[main_domain] = [];
+                var domains = urls[main_domain];
+                var domains_count = domains.length;
+
+                for (var j = 0; j < domains_count; j++) {
+                  blocklist[domains[j]] = main_domain;
+                }
+
+              }
+
+            }
+
+          }
+
+        }
+        resolve(blocklist);
       } else {
         reject(status);
       }
     };
     xhr.send();
+});
+
+
+var getAllowedHosts = new Promise(function(resolve, reject) {
+  browser.storage.local.get("allowedHosts", function(item) {
+    if (Object.keys(item).length === 0) {
+      allowedHosts = [];
+    } else {
+      allowedHosts = item;
+    }
+    resolve(allowedHosts);
   });
-}
+});
 
 
 function blockTrackerRequests(requestDetails) {
     var blockTrackerRequestsStart = Date.now();
-    var current_tab_disabled_index = disabled_tabs.indexOf(current_active_tab_id);
-    var originTopHost = new URL(requestDetails.originUrl).host.split('.').slice(-2).join('.');
+    var requestTabID = requestDetails.tabId;
+    console.log("requestTabID: " + requestTabID);
+    var originTopHost, requestTopHost;
+    if (requestDetails.hasOwnProperty('originUrl')) {
+      originTopHost = new URL(requestDetails.originUrl).host.split('.').slice(-2).join('.');
+    }
     var requestTopHost = new URL(requestDetails.url).host.split('.').slice(-2).join('.');
 
-    // When the user goes to a new domain,
-    // remove the tabID from disabled_tabs, and reset active origin
-    // so protection is re-enabled in the tab for the new domain
-    if (originTopHost != current_active_origin) {
-      disabled_tabs.splice(current_tab_disabled_index, 1);
-      current_active_origin = originTopHost;
-      current_tab_disabled_index = disabled_tabs.indexOf(current_active_tab_id);
-    }
+    current_active_origin = originTopHost;
+    var current_origin_disabled_index = allowedHosts.indexOf(current_active_origin);
 
-    // Allow request if protection for this tab has been disabled
-    if (current_tab_disabled_index > -1) {
-      console.log("Protection disabled for this tab; allowing request.");
+    // Allow request if the origin has been added to allowedHosts
+    if (current_origin_disabled_index > -1) {
+      console.log("Protection disabled for this site; allowing request.");
       return {};
     }
 
     // Allow request originating from Firefox new tab/window pages
     if (requestDetails.originUrl.includes('moz-nullprincipal')) {
-        total_exec_time[current_active_tab_id] += Date.now() - blockTrackerRequestsStart;
+        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
         return {};
     }
 
     // Allow requests to 3rd-party domains NOT in the block-list
     if (!blocklist.hasOwnProperty(requestTopHost)) {
-        total_exec_time[current_active_tab_id] += Date.now() - blockTrackerRequestsStart;
+        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
         return {};
     }
 
     // Block if the request url top host doesn't match origin url top host (i.e., 3rd-party)
     if (requestTopHost != originTopHost) {
       console.log("requestTopHost: " + requestTopHost + " does not match originTopHost: " + originTopHost + ". Blocking request.");
-      blocked_requests[current_active_tab_id].push(requestTopHost);
-      console.log("blocked_requests: " + blocked_requests[current_active_tab_id]);
+      blocked_requests[requestTabID].push(requestTopHost);
+      console.log("blocked " + blocked_requests[requestTabID].length + " requests: " + blocked_requests[requestTabID]);
 
-      total_exec_time[current_active_tab_id] += Date.now() - blockTrackerRequestsStart;
-      console.log("total_exec_time: " + total_exec_time[current_active_tab_id]);
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
+      console.log("total_exec_time: " + total_exec_time[requestTabID]);
+      chrome.pageAction.show(requestTabID);
 
       return {cancel: true};
     }
 }
 
 
-getJSON(blocklist_url).then(function(data) {
-  // remove un-needed categories per disconnect
-  delete data.categories['Content'];
-  delete data.categories['Legacy Disconnect'];
-  delete data.categories['Legacy Content'];
-
-  // parse thru the disconnect blocklist and create
-  // local blocklist "grouped" by main domain. I.e.,
-  // blocklist["facebook.com"] = http://www.facebook.com
-  // blocklist["fb.com"] = http://www.facebook.com
-  // blocklist["doubleclick.net"] = http://www.google.com
-  // blocklist["google-analytics.com"] = http://www.google.com
-  // etc.
-  for (category_name in data.categories) {
-    var category = data.categories[category_name];
-    var entity_count = category.length;
-
-    for (var i = 0; i < entity_count; i++) {
-      var entity = category[i];
-
-      for (entity_name in entity) {
-        var urls = entity[entity_name];
-
-        for (main_domain in urls) {
-          blocklist[main_domain] = [];
-          var domains = urls[main_domain];
-          var domains_count = domains.length;
-
-          for (var j = 0; j < domains_count; j++) {
-            blocklist[domains[j]] = main_domain;
-          }
-
-        }
-
-      }
-
-    }
-
-  }
-
+Promise.all([getBlocklistJSON, getAllowedHosts]).then(function(values) {
   chrome.webRequest.onBeforeRequest.addListener(
       blockTrackerRequests,
       {urls:["*://*/*"]},
@@ -134,12 +144,6 @@ chrome.tabs.onActivated.addListener(function(activeInfo) {
 
 chrome.tabs.onUpdated.addListener(function(tabID, changeInfo) {
   if (changeInfo.status == "loading") {
-    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-      current_active_tab_id = tabs[0].id;
-      restartBlok(current_active_tab_id);
-      if (tabID == tabs[0].id) {
-        chrome.pageAction.show(current_active_tab_id);
-      }
-    });
+    restartBlokForTab(tabID);
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,7 @@
   },
 
   "permissions": [
+    "storage",
     "webRequest",
     "webRequestBlocking"
   ]

--- a/popup.html
+++ b/popup.html
@@ -12,7 +12,7 @@
   <div id="details" class="row">
     <img id="banner" src="img/banner.png">
     <p id="blocking_summary">Blocked <span id="blocked_requests_count"></span> request(s) on the page that may track your browsing.</p>
-    <input id="disable_btn" class="button expanded" value="Disable blocking for this site in this tab"></input>
+    <input id="disable_btn" class="button expanded" value="Disable blocking for this site"></input>
   </div>
   <div id="disabled_reason_buttons" class="hide">
     <input class="reason button expanded" value="The page was broken"></input>

--- a/popup.js
+++ b/popup.js
@@ -1,22 +1,25 @@
 browser.runtime.getBackgroundPage(function(backgroundPage) {
   var current_active_tab_id = backgroundPage.current_active_tab_id;
+  var current_active_origin = backgroundPage.current_active_origin;
   var blocked_requests = backgroundPage.blocked_requests;
   var blocked_requests_count = blocked_requests[current_active_tab_id].length;
-  var disabled_tabs = backgroundPage.disabled_tabs;
-  var current_tab_disabled_index = disabled_tabs.indexOf(current_active_tab_id);
+  var allowedHosts = backgroundPage.allowedHosts;
+  var current_origin_disabled_index = allowedHosts.indexOf(current_active_origin);
 
-  if (current_tab_disabled_index > -1) {
-    document.querySelector("#blocking_summary").innerHTML = "Blocking disabled for this site in this tab";
+  if (current_origin_disabled_index > -1) {
+    document.querySelector("#blocking_summary").innerHTML = "Blocking disabled for this site";
     document.querySelector("#disable_btn").value = "Re-enable blocking for this site in this tab";
     document.querySelector("#disable_btn").addEventListener("click", function(){
-      disabled_tabs.splice(current_tab_disabled_index, 1);
+      allowedHosts.splice(current_origin_disabled_index, 1);
+      browser.storage.local.set({allowedHosts: allowedHosts});
       browser.tabs.reload(current_active_tab_id);
       window.close();
     });
   } else {
     document.querySelector("#blocked_requests_count").innerHTML = blocked_requests_count;
     document.querySelector("#disable_btn").addEventListener("click", function(){
-      disabled_tabs.push(current_active_tab_id);
+      allowedHosts.push(current_active_origin);
+      browser.storage.local.set({allowedHosts: allowedHosts});
       browser.tabs.reload(current_active_tab_id);
       document.querySelector("#disabled_reason_buttons").className = "";
       document.querySelector("#details").className = "row hide";


### PR DESCRIPTION
To preserve hosts where the user has disabled tracking protection,
store the allowed hosts in extension local storage.

To show accurate block stats in each tab, use requestDetails.tabId
when recording block stats.